### PR TITLE
added destroyStream method 

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,12 @@ function Multiplex(opts, onStream) {
     encoder.meta = id.toString()
     return encoder
   }
+
+  function destroyStream(id) {
+    delete self.streams[id]
+  }
   
   reader.createStream = createStream
+  reader.destroyStream = destroyStream
   return reader
 }


### PR DESCRIPTION
Since there's no such thing as destroy this methods removes the sub-stream from `this.streams`; I use it sometimes with the `end` event when I no longer need to use the stream.

(Love multiplex!)
