### PR TITLE
added optional onFromatError

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,20 +8,20 @@ var dataVal = new Buffer('d')[0]
 var errorVal = new Buffer('e')[0]
 var empty = new Buffer(0)
 
-function Multiplex(opts, onStream, onFormatErr) {
-  if (!(this instanceof Multiplex)) return new Multiplex(opts, onStream, onFormatErr)
-  
-  var self = this
-  var args = [].slice.call(arguments)
+function Multiplex(opts, onStream) {
+  if (!(this instanceof Multiplex)) return new Multiplex(opts, onStream)  
 
-  if (typeof args[0] === 'function') {
-    onStream = args[0]
-    onFormatErr = args[1] || null
+  if (typeof opts === 'function') {
+    onStream = opts
+    opts = {}
+  }
+  
+  if (!opts) {
     opts = {}
   }
 
-  opts = opts || {}  
-  
+  var self = this
+
   this.idx = 0
   this.streams = {}
   
@@ -50,14 +50,11 @@ function Multiplex(opts, onStream, onFormatErr) {
   }
   
   function createOrPush(id, chunk, type) {
-    if (id === null) {
-      onFormatErr && onFormatErr()
-      return
-    }    
+    if (null === id && onStream) return onStream(new Error('Invalid data'))
     if (Object.keys(self.streams).indexOf(id + '') === -1) {
       var created = createStream(id)
       created.meta = id.toString()
-      if (onStream) onStream(created, created.meta)
+      if (onStream) onStream(null, created, created.meta)
     }
     if (chunk.length === 0) return self.streams[id].end()
     if (type === dataVal) self.streams[id].push(chunk)


### PR DESCRIPTION
Given:

```
var s = MyDummyStream // not a plexed stream
var p = multiplex(function onStream(stream, id) {})
s.pipe(p)
```

The following would throw an error and break multiplex (obviously because s is not plexed):

```
s.write('some troll is trying to do some flooding')
```

As a developer one deserves multiplex to crash in this case but when used along WebsocketStream anyone sending any dummy data would cause multiplex to throw an error.

This pull adds an optional onFormatErr callback which is triggered whenever the above happens. 

Constructor same as before:

```
multiplex = require('multiplex')([opts],[onStream],[onFormatErr])
```
