### PR TITLE
Fix to add support for node 0.10

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ Channel.prototype.destroy = function (err) {
 Channel.prototype._destroy = function (err, local) {
   if (this.destroyed) return
   this.destroyed = true
-  if (err && (!local || events.listenerCount(this, 'error'))) this.emit('error', err)
+  if (err && (!local || this.listeners('error').length)) this.emit('error', err)
   this.emit('close')
   if (local && this._opened) {
     if (this._lazy && this.initiator) this._open()


### PR DESCRIPTION
`events.listenerCount(this, 'error')` is only available in node [0.12](https://nodejs.org/docs/v0.12.4/api/events.html), not in node [0.10](https://nodejs.org/docs/v0.10.36/api/events.html). `emitter.listeners('error').length` should work in both versions.