### PR TITLE
fix for push after EOF error

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,9 @@ Channel.prototype._destroy = function (err, local) {
   this.emit('close')
   if (local && this._opened) {
     if (this._lazy && this.initiator) this._open()
-    this._multiplex._send(this.channel << 3 | (this.initiator ? 6 : 5), err ? new Buffer(err.message) : null)
+    try {
+      this._multiplex._send(this.channel << 3 | (this.initiator ? 6 : 5), err ? new Buffer(err.message) : null)
+    } catch (e) {}
   }
   this._finalize()
 }


### PR DESCRIPTION
I haven't been able to reproduce this error in the test suite, but before I was getting this error when I called `stream.end()` on a multiplexed stream:

```
Error: stream.push() after EOF
    at readableAddChunk (/home/substack/projects/multiplex/node_modules/readable-stream/lib/_stream_readable.js:185:15)
    at Readable.push (/home/substack/projects/multiplex/node_modules/readable-stream/lib/_stream_readable.js:163:10)
    at Multiplex._send (/home/substack/projects/multiplex/index.js:185:18)
    at Channel._destroy (/home/substack/projects/multiplex/index.js:69:21)
    at Channel.destroy (/home/substack/projects/multiplex/index.js:59:8)
    at Duplexify._destroy (/home/substack/projects/multiplex/node_modules/duplexify/index.js:187:66)
    at /home/substack/projects/multiplex/node_modules/duplexify/index.js:174:10
    at doNTCallback0 (node.js:417:9)
    at process._tickCallback (node.js:346:13)
```

and this patch keeps this error from happening.