### PR TITLE
fix: close muxed streams when underlying socket is closed

### DIFF
--- a/index.js
+++ b/index.js
@@ -407,10 +407,21 @@ Multiplex.prototype.finalize = function () {
 
 Multiplex.prototype.destroy = function (err) {
   if (this.destroyed) return
+
+  var list = this._local.concat(this._remote)
+
   this.destroyed = true
-  this._clear()
+
   if (err) this.emit('error', err)
   this.emit('close')
+
+  list.forEach(function (stream) {
+    if (stream) {
+      stream.emit('error', err || new Error('underlying socket has been closed'))
+    }
+  })
+
+  this._clear()
 }
 
 module.exports = Multiplex

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "chunky": "0.0.0",
     "concat-stream": "^1.4.8",
+    "pump": "^1.0.2",
     "tape": "^4.0.0",
     "through2": "^0.6.5"
   },


### PR DESCRIPTION
Hi all!

We've been updating our libp2p-multiplex wrap (exposing pull-streams instead of Node.js streams and conforming with the interface defined on https://github.com/libp2p/interface-stream-muxer) and found that one of our expectations that is met with `spdy-transport`, wasn't met with `multiplex`, that is: 

- `'when the underlying socket is closed, every stream should be closed as well'.`

This PR changes multiplex so that it does that.

In addition to this, we learned that now multiplex also passes our ['mega stress test'](https://github.com/libp2p/interface-stream-muxer/blob/master/src/mega-stress-test.js#L19-L21), which previously would make multiplex error with OOM thrown.

I've added a test for this new behaviour. One Caveat is that now, since errors are propagated, you have to listen for errors on each stream, otherwise they will be process unCaught exceptions, I've updated the test 'overflow' because of this.

