### PR TITLE
fix typo in package.json license string

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "Ayman Mackouly <ayman.mackouly@gmail.com> (https://github.com/1N50MN14/)"
   ],
   "author": "max ogden",
-  "license": "BSD 2-Clause",
+  "license": "BSD-2-Clause",
   "dependencies": {
     "duplexify": "^3.4.2",
     "inherits": "^2.0.1",


### PR DESCRIPTION
Howdy @maxogden!

Thanks for this package, too!  I've found it very handy minimizing WebRTC replication connections for proseline.com.

Noticed the `license` property in `package.json` is one character away from standard.  Here's a tiny patch to fix it.

Hope you're well.